### PR TITLE
Define to_expr(::Number) in order to handle e.g. default array sizes

### DIFF
--- a/src/CompositeStructs.jl
+++ b/src/CompositeStructs.jl
@@ -18,9 +18,9 @@ end
 # convert a type or UnionAll back to an expression
 to_expr(t::DataType) = isempty(t.parameters) ? t.name.name : :($(t.name.name){$(map(to_expr,t.parameters)...)})
 to_expr(t::TypeVar) = t.name
-to_expr(t::Symbol) = t
+to_expr(t::Symbol) = QuoteNode(t)
 to_expr(t::UnionAll) = :($(to_expr(t.body)) where {$(t.var.lb) <: $(t.var.name) <: $(t.var.ub)})
-to_expr(t::Number) = t
+to_expr(t) = t
 
 # given an expression like :(Complex{T}) and a module in which the
 # relevant symbols are defined, return an array with the struct's

--- a/src/CompositeStructs.jl
+++ b/src/CompositeStructs.jl
@@ -20,6 +20,7 @@ to_expr(t::DataType) = isempty(t.parameters) ? t.name.name : :($(t.name.name){$(
 to_expr(t::TypeVar) = t.name
 to_expr(t::Symbol) = t
 to_expr(t::UnionAll) = :($(to_expr(t.body)) where {$(t.var.lb) <: $(t.var.name) <: $(t.var.ub)})
+to_expr(t::Number) = t
 
 # given an expression like :(Complex{T}) and a module in which the
 # relevant symbols are defined, return an array with the struct's

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -126,18 +126,27 @@ using CompositeStructs, Test
 
     end
 
-    # mutable structs, with @kwdef and default array size
+    # type arguments which are constants
     @test_nowarn @eval module $(gensym())
-    using CompositeStructs
-    Base.@kwdef mutable struct FOO
-	n::Int=10
-	a::Vector{Float64}=zeros(n)
-    end
+        using CompositeStructs
 
-    @composite Base.@kwdef mutable struct ExtFOO
-	   FOO...
-	b=2
-    end
+        Base.@kwdef mutable struct Foo{T}
+            a :: Vector{Float64}
+            b :: Val{:x}
+            c :: NamedTuple{(:x,:y), S} where S <: Tuple
+            d :: Vector{T}
+        end
+
+        @composite Base.@kwdef mutable struct Bar{T}
+            Foo{T}...
+        end
+
+        mutable struct Bar{T}
+            a :: Vector{Float64}
+            b :: Val{:x}
+            c :: NamedTuple{(:x,:y), S} where S <: Tuple
+            d :: Vector{T}
+        end
 
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -125,7 +125,22 @@ using CompositeStructs, Test
         @test ParentOuter(x=1, y=2, w=4) == ParentOuter{Int64}(1,2,3,4)
 
     end
-    
+
+    # mutable structs, with @kwdef and default array size
+    @test_nowarn @eval module $(gensym())
+    using CompositeStructs
+    Base.@kwdef mutable struct FOO
+	n::Int=10
+	a::Vector{Float64}=zeros(n)
+    end
+
+    @composite Base.@kwdef mutable struct ExtFOO
+	   FOO...
+	b=2
+    end
+
+    end
+
 end
 
 


### PR DESCRIPTION
Hi, I had a parent struct containing an array with default size being in that struct as well. Got metod error "Missing `to_expr(::Int64)` . With defining this, the problem goes away.

I added the MWE as a test.
