### PR TITLE
Correctly handle field docstrings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,8 @@ version = "0.1.4"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [compat]
-julia = "1.3"
 MacroTools = "0.5"
+julia = "1.3"

--- a/src/CompositeStructs.jl
+++ b/src/CompositeStructs.jl
@@ -84,7 +84,7 @@ macro composite(ex)
     for x in parent_body
         if !(x isa String) && @capture(x, ChildType_...) && @capture(ChildType, ChildName_{__} | ChildName_)
             child_fields_and_docstrings = (reconstruct_fields_and_docstrings(__module__, ChildType)...,)
-            child_field_names = _field_name.(filter(x -> !(x isa String), child_fields_and_docstrings))
+            child_field_names = _field_name.(filter(x -> !(x isa String), collect(child_fields_and_docstrings)))
             append!(parent_body′, child_fields_and_docstrings)
             child_instance = gensym()
             push!(generic_child_constructors,  :($child_instance = $ChildName(; filter(((k,_),)->(k in $child_field_names), kw)...)))

--- a/src/CompositeStructs.jl
+++ b/src/CompositeStructs.jl
@@ -83,7 +83,7 @@ macro composite(ex)
     for x in parent_body
         if @capture(x, ChildType_...) && @capture(ChildType, ChildName_{__} | ChildName_)
             child_fields = (reconstruct_fields(__module__, ChildType)...,)
-            child_field_names = filter(x->!isnothing(x),_field_name.(child_fields))
+            child_field_names = filter(x->!isnothing(x),[_field_name.(child_fields)...])
             append!(parent_body′, child_fields)
             child_instance = gensym()
             push!(generic_child_constructors,  :($child_instance = $ChildName(; filter(((k,_),)->(k in $child_field_names), kw)...)))

--- a/src/CompositeStructs.jl
+++ b/src/CompositeStructs.jl
@@ -28,7 +28,7 @@ to_expr(t)= t
 # Thanks https://discourse.julialang.org/t/accessing-docstring-of-a-field/4830/7 !
 function fielddoc(binding::Binding, field::Symbol)
     for mod in modules
-        dict = meta(mod; autoinit=false)
+        dict = meta(mod)
         isnothing(dict) && continue
         if haskey(dict, binding)
             multidoc = dict[binding]
@@ -53,7 +53,6 @@ fielddocs(object)=map(sym->fielddoc(object,sym), fieldnames(object))
 function reconstruct_fields(__module__, ex)
     t = reconstruct_type(__module__, ex)
     (t isa UnionAll) && error("Spliced type $ex must not have any free type parameters.")
-    fnames=fieldnames(t)
     flatten(zip(fielddocs(t),map( xT->:($(first(xT))::$(to_expr(last(xT)))) , zip(fieldnames(t),datatype_fieldtypes(t)))))
 end
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,2 +1,3 @@
 [deps]
+DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -190,54 +190,25 @@ using CompositeStructs, Test, DocStringExtensions
         $(TYPEDEF)
         $(TYPEDFIELDS)
         """
-        struct Foo{X,Y}
+        Base.@kwdef struct Foo{X,Y}
             "foo_x"
-            x :: X
+            x :: X = 1
             "foo_y"
-            y :: Y
+            y :: Y = 2
         end
         """
         $(TYPEDEF)
         $(TYPEDFIELDS)
         """
-        @composite struct Bar{X,Y,Z}
+        @composite Base.@kwdef struct Bar{X,Y,Z}
             Foo{X,Y}...
             "bar_z"
-            z :: Z
+            z :: Z = 3
         end
         @test occursin("foo_x", string(@doc Bar))
         @test occursin("foo_y", string(@doc Bar))
         @test occursin("bar_z", string(@doc Bar))
-    end
-
-    
-    # docstring extension handling
-    @test_nowarn @eval module $(gensym())
-        using CompositeStructs
-        using DocStringExtensions
-        using Test
-        """
-        $(TYPEDEF)
-        $(TYPEDFIELDS)
-        """
-        Base.@kwdef struct Foo
-            "foo_x"
-            x :: Int = 1
-            "foo_y"
-            y :: Int = 2
-        end
-        """
-        $(TYPEDEF)
-        $(TYPEDFIELDS)
-        """
-        @composite struct Bar
-            Foo...
-            "bar_z"
-            z :: Int = 3
-        end
-        @test occursin("foo_x", string(@doc Bar))
-        @test occursin("foo_y", string(@doc Bar))
-        @test occursin("bar_z", string(@doc Bar))
+        @test Bar() == Bar(1,2,3)
     end
 
     

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 
-using CompositeStructs, Test
+using CompositeStructs, Test, DocStringExtensions
 
 @testset "CompositeStructs" begin
 
@@ -181,7 +181,35 @@ using CompositeStructs, Test
 
     end
       
+    # docstring extension handling
+    # this just tests that the code runs, but not the result in the docstring
+    @test_nowarn @eval module $(gensym())
+        using CompositeStructs
+        using DocStringExtensions
+        using Test
+        """
+        $(TYPEDEF)
+        $(TYPEDFIELDS)
+        """
+        struct Foo{X,Y}
+            "foo_x"
+            x :: X
+            "foo_y"
+            y :: Y
+        end
+        """
+        $(TYPEDEF)
+        $(TYPEDFIELDS)
+        """
+        @composite struct Bar{X,Y,Z}
+            Foo{X,Y}...
+            "bar_z"
+            z :: Z
+        end
+        @test occursin("foo_x", string(@doc Bar))
+    end
 
+    
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -182,7 +182,6 @@ using CompositeStructs, Test, DocStringExtensions
     end
       
     # docstring extension handling
-    # this just tests that the code runs, but not the result in the docstring
     @test_nowarn @eval module $(gensym())
         using CompositeStructs
         using DocStringExtensions
@@ -205,6 +204,34 @@ using CompositeStructs, Test, DocStringExtensions
             Foo{X,Y}...
             "bar_z"
             z :: Z
+        end
+        @test occursin("foo_x", string(@doc Bar))
+    end
+
+    
+    # docstring extension handling
+    @test_nowarn @eval module $(gensym())
+        using CompositeStructs
+        using DocStringExtensions
+        using Test
+        """
+        $(TYPEDEF)
+        $(TYPEDFIELDS)
+        """
+        Base.@kwdef struct Foo
+            "foo_x"
+            x :: Int = 1
+            "foo_y"
+            y :: Int = 2
+        end
+        """
+        $(TYPEDEF)
+        $(TYPEDFIELDS)
+        """
+        @composite struct Bar
+            Foo...
+            "bar_z"
+            z :: Int = 3
         end
         @test occursin("foo_x", string(@doc Bar))
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -206,6 +206,8 @@ using CompositeStructs, Test, DocStringExtensions
             z :: Z
         end
         @test occursin("foo_x", string(@doc Bar))
+        @test occursin("foo_y", string(@doc Bar))
+        @test occursin("bar_z", string(@doc Bar))
     end
 
     
@@ -234,6 +236,8 @@ using CompositeStructs, Test, DocStringExtensions
             z :: Int = 3
         end
         @test occursin("foo_x", string(@doc Bar))
+        @test occursin("foo_y", string(@doc Bar))
+        @test occursin("bar_z", string(@doc Bar))
     end
 
     


### PR DESCRIPTION
Make this work:
```julia
        using CompositeStructs
        using DocStringExtensions
        using Test
        """
        $(TYPEDEF)
        $(TYPEDFIELDS)
        """
        struct Foo{X,Y}
            "foo_x"
            x :: X
            "foo_y"
            y :: Y
        end
        """
        $(TYPEDEF)
        $(TYPEDFIELDS)
        """
        @composite struct Bar{X,Y,Z}
            Foo{X,Y}...
            "bar_z"
            z :: Z
        end
        @test occursin("foo_x", string(@doc Bar))
```